### PR TITLE
Add Nix flake with container build

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,26 @@ In addition to the packages specified in the table above, the following packages
 - `bazelisk` / `bazel`
 
 See [Dockerfile](Dockerfile) for the full details of installed packages.
+
+## Building with Nix
+
+You can build an equivalent image using [Nix](https://nixos.org/). The repository provides a Flake that produces a Docker image and a development shell. Ensure `nix` is installed with flakes enabled. To build the image:
+
+```bash
+nix build .#dockerImage
+```
+
+The resulting `result` symlink can be loaded with Docker:
+
+```bash
+docker load < result
+```
+
+A development shell with the required tools can be entered with:
+
+```bash
+nix develop
+```
+
+This shell enables the `nix-command` and `flakes` features by default.
+

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,54 @@
+{
+  description = "Codex universal container using Nix";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.05";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+
+        envPackages = with pkgs; [
+          bashInteractive
+          git
+          git-lfs
+          curl
+          jq
+          gnupg
+          ripgrep
+          rsync
+          unzip
+          zip
+          python311Full
+          nodejs_22
+          bun
+          jdk21
+          ruby_3_2
+          rustup
+          go_1_23
+          swift
+          bazelisk
+          nix
+        ];
+
+        entry = pkgs.writeShellScriptBin "entrypoint.sh" (builtins.readFile ./entrypoint.sh);
+        setupScript = pkgs.writeShellScriptBin "setup_universal.sh" (builtins.readFile ./setup_universal.sh);
+
+      in {
+        packages.dockerImage = pkgs.dockerTools.buildLayeredImage {
+          name = "codex-universal";
+          contents = envPackages ++ [ entry setupScript ];
+          config = {
+            Entrypoint = [ "${entry}/bin/entrypoint.sh" ];
+            Env = [ "NIX_CONFIG=experimental-features\ =\ nix-command\ flakes" ];
+          };
+        };
+
+        devShells.default = pkgs.mkShell {
+          packages = with pkgs; [ nix docker-compose ];
+        };
+      });
+}


### PR DESCRIPTION
## Summary
- provide a `flake.nix` that builds a container using `dockerTools`
- include a dev shell for local development
- document how to build and load the image with Nix

## Testing
- `git status --short`
