### PR TITLE
chore: migrate Nix cache action to nix-community/cache-nix-action@v6

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -16,8 +16,11 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v10
-      - name: Configure Nix cache
-        uses: DeterminateSystems/setup-nix-cache@v3
+      - name: Restore and save Nix store
+        uses: nix-community/cache-nix-action@v6
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-
       - name: Build container image
         run: nix build .#dockerImage
       - name: Load image

--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -17,8 +17,11 @@ jobs:
           fetch-depth: 0
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v10
-      - name: Configure Nix cache
-        uses: DeterminateSystems/setup-nix-cache@v3
+      - name: Restore and save Nix store
+        uses: nix-community/cache-nix-action@v6
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-
       - name: Update lock file
         run: nix flake lock --commit-lock-file
       - name: Commit changes


### PR DESCRIPTION
Replace deprecated DeterminateSystems/setup-nix-cache@v3 with nix-community/cache-nix-action@v6, updating step names and adding required inputs for primary-key and restore-prefixes-first-match.
