### PR TITLE
refactor: establish AGENT.md as standard AI assistant guidance file

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1,6 +1,6 @@
-# CLAUDE.md
+# AGENT.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This file provides guidance for AI assistants when working with code in this repository.
 
 ## Project Overview
 

--- a/README.md
+++ b/README.md
@@ -107,3 +107,22 @@ Nix-related environment variables can also be set as needed, such as:
 ```bash
 NIX_PATH=nixpkgs=./nixpkgs nix build
 ```
+
+## AI Assistant Guidance
+
+This repository includes an `AGENT.md` file that provides guidance for AI assistants working with the codebase. To integrate with different AI tools, you can create symlinks to this file:
+
+```bash
+# For tools expecting AGENTS.md
+ln -s AGENT.md AGENTS.md
+
+# For other common naming conventions
+ln -s AGENT.md AI.md
+ln -s AGENT.md ASSISTANT.md
+```
+
+The guidance file includes:
+- Project architecture overview
+- Common commands and workflows
+- Language version configuration details
+- Build process documentation


### PR DESCRIPTION
## Summary

This PR renames `CLAUDE.md` to `AGENT.md` to establish a vendor-neutral naming convention for AI assistant guidance files.

## Changes

1. Renamed `CLAUDE.md` to `AGENT.md`
2. Removed references to specific AI services 
3. Added README documentation explaining how to create symlinks for compatibility with different AI tools

## Rationale

As more AI coding assistants emerge, it's better to use a generic naming convention that any tool can adopt. The README now includes instructions for creating symlinks like:
- `AGENTS.md` 
- `AI.md`
- `ASSISTANT.md`

This allows projects to support multiple AI tools without being tied to a specific service.