### PR TITLE
Fix duplicate mkdir in codexScripts

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -42,7 +42,6 @@
           mkdir -p $out/opt/codex
           cp ${./setup_universal.sh} $out/opt/codex/setup_universal.sh
           chmod +x $out/opt/codex/setup_universal.sh
-          mkdir -p $out/opt/codex
           cp ${./entrypoint.sh} $out/opt/codex/entrypoint.sh
           chmod +x $out/opt/codex/entrypoint.sh
         '';


### PR DESCRIPTION
## Summary
- simplify `codexScripts` by removing the repeated directory creation step

## Testing
- `nix flake show` *(fails: `nix` command not found)*