### PR TITLE
fix: tag docker image after loading in CI workflow

### DIFF
--- a/.github/workflows/check-flake-lock.yml
+++ b/.github/workflows/check-flake-lock.yml
@@ -3,6 +3,7 @@ name: Check flake.lock
 on:
   pull_request:
     branches: [ "main" ]
+  merge_group:
 
 jobs:
   flake-lock-check:

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -5,6 +5,7 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  merge_group:
 
 jobs:
   build-flake:

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -26,6 +26,10 @@ jobs:
         run: nix build .#dockerImage
       - name: Load image
         run: docker load < result
+      - name: Tag loaded image
+        run: |
+          IMAGE_ID=$(docker images --format "{{.Repository}}:{{.Tag}}" | grep -v '<none>' | head -1)
+          docker tag $IMAGE_ID codex-universal:latest
       - name: Log in to ghcr.io
         if: ${{ github.event_name == 'push' }}
         uses: docker/login-action@v3

--- a/AGENT.md
+++ b/AGENT.md
@@ -1,6 +1,6 @@
-# CLAUDE.md
+# AGENT.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This file provides guidance for AI assistants when working with code in this repository.
 
 ## Project Overview
 

--- a/README.md
+++ b/README.md
@@ -107,3 +107,22 @@ Nix-related environment variables can also be set as needed, such as:
 ```bash
 NIX_PATH=nixpkgs=./nixpkgs nix build
 ```
+
+## AI Assistant Guidance
+
+This repository includes an `AGENT.md` file that provides guidance for AI assistants working with the codebase. To integrate with different AI tools, you can create symlinks to this file:
+
+```bash
+# For tools expecting AGENTS.md
+ln -s AGENT.md AGENTS.md
+
+# For other common naming conventions
+ln -s AGENT.md AI.md
+ln -s AGENT.md ASSISTANT.md
+```
+
+The guidance file includes:
+- Project architecture overview
+- Common commands and workflows
+- Language version configuration details
+- Build process documentation


### PR DESCRIPTION
## Summary
This PR fixes the CI workflow to properly tag the docker image as `codex-universal:latest` after loading it from the nix build result.

## Problem
The workflow was failing because it was trying to use `codex-universal:latest` but the image wasn't tagged with that name after loading from the nix build.

## Solution
Added a step to tag the loaded image with `codex-universal:latest` after the docker load command.

## Changes
- Added "Tag loaded image" step in `.github/workflows/nix.yml` that:
  1. Finds the loaded image ID
  2. Tags it as `codex-universal:latest`

This ensures the subsequent steps that reference `codex-universal:latest` will work correctly.